### PR TITLE
日期选择器修改

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -2752,6 +2752,43 @@ export const Calendar = React.memo(
         const createTitleMonthElement = (month, monthIndex) => {
             const monthNames = localeOption('monthNames', props.locale);
 
+            // if (renderMonthsNavigator(monthIndex)) {
+            //     const viewDate = getViewDate();
+            //     const viewMonth = viewDate.getMonth();
+            //     const displayedMonthOptions = monthNames
+            //         .map((month, index) => ((!isInMinYear(viewDate) || index >= props.minDate.getMonth()) && (!isInMaxYear(viewDate) || index <= props.maxDate.getMonth()) ? { label: month, value: index, index } : null))
+            //         .filter((option) => !!option);
+            //     const displayedMonthNames = displayedMonthOptions.map((option) => option.label);
+            //     const selectProps = mergeProps(
+            //         {
+            //             className: cx('select'),
+            //             onChange: (e) => onMonthDropdownChange(e, e.target.value),
+            //             value: viewMonth
+            //         },
+            //         ptm('select')
+            //     );
+            //     const content = (
+            //         <select {...selectProps}>
+            //             {displayedMonthOptions.map((option) => {
+            //                 const optionProps = mergeProps(
+            //                     {
+            //                         value: option.value
+            //                     },
+            //                     ptm('option')
+            //                 );
+
+            //                 return (
+            //                     <option {...optionProps} key={option.label}>
+            //                         {option.label}
+            //                     </option>
+            //                 );
+            //             })}
+            //         </select>
+            //     );
+
+            //     return content;
+            // }
+
             if (props.monthNavigatorTemplate) {
                 const viewDate = getViewDate();
                 const viewMonth = viewDate.getMonth();
@@ -2803,6 +2840,33 @@ export const Calendar = React.memo(
                 const viewDate = getViewDate();
                 const viewYear = viewDate.getFullYear();
                 const displayedYearNames = yearOptions.filter((year) => !(props.minDate && props.minDate.getFullYear() > year) && !(props.maxDate && props.maxDate.getFullYear() < year));
+                // const selectProps = mergeProps(
+                //     {
+                //         className: cx('select'),
+                //         onChange: (e) => onYearDropdownChange(e, e.target.value),
+                //         value: viewYear
+                //     },
+                //     ptm('select')
+                // );
+
+                // const content = (
+                //     <select {...selectProps}>
+                //         {displayedYearNames.map((year) => {
+                //             const optionProps = mergeProps(
+                //                 {
+                //                     value: year
+                //                 },
+                //                 ptm('option')
+                //             );
+
+                //             return (
+                //                 <option {...optionProps} key={year}>
+                //                     {year}
+                //                 </option>
+                //             );
+                //         })}
+                //     </select>
+                // );
 
                 if (props.yearNavigatorTemplate) {
                     const options = yearPickerValues();
@@ -2938,12 +3002,7 @@ export const Calendar = React.memo(
                 })
             );
 
-            return (
-                <span {...dayLabelProps}>
-                    {content}
-                    <Ripple />
-                </span>
-            );
+            return <span {...dayLabelProps}>{content}</span>;
         };
 
         const createWeek = (weekDates, weekNumber, groupIndex) => {

--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -22,14 +22,15 @@ export const Calendar = React.memo(
         const [focusedState, setFocusedState] = React.useState(false);
         const [overlayVisibleState, setOverlayVisibleState] = React.useState(false);
         const [viewDateState, setViewDateState] = React.useState(null);
-        const [multiplePickerShow, setMultiplePickerShow] = React.useState(false);
+        const [currentView, setCurrentView] = React.useState('date');
+
         const metaData = {
             props,
             state: {
                 focused: focusedState,
                 overlayVisible: overlayVisibleState,
                 viewDate: viewDateState,
-                multiplePickerShow
+                currentView
             }
         };
         const { ptm, cx, isUnstyled } = CalendarBase.setMetaData(metaData);
@@ -50,7 +51,6 @@ export const Calendar = React.memo(
         const nextButton = React.useRef(false);
         const onChangeRef = React.useRef(null);
 
-        const [currentView, setCurrentView] = React.useState('date');
         const [currentMonth, setCurrentMonth] = React.useState(null);
         const [currentYear, setCurrentYear] = React.useState(null);
         const [yearOptions, setYearOptions] = React.useState([]);
@@ -1418,20 +1418,8 @@ export const Calendar = React.memo(
             event.preventDefault();
         };
 
-        const multiplePickerMonth = (event) => {
-            switchToMonthView(event);
-            setMultiplePickerShow(true);
-            event.preventDefault();
-        };
-
         const switchToYearView = (event) => {
             setCurrentView('year');
-            event.preventDefault();
-        };
-
-        const multiplePickerYear = (event) => {
-            switchToYearView(event);
-            setMultiplePickerShow(true);
             event.preventDefault();
         };
 
@@ -1450,7 +1438,6 @@ export const Calendar = React.memo(
 
                 setViewDateState(currentDate);
                 setCurrentView('date');
-                setMultiplePickerShow(false);
                 props.onMonthChange && props.onMonthChange({ month: month + 1, year: currentYear });
             }
         };
@@ -2783,7 +2770,7 @@ export const Calendar = React.memo(
                     element: null,
                     displayMonth: displayedMonthNames[idx],
                     props,
-                    multiplePickerMonth,
+                    switchToMonthView,
                     currentView
                 };
 
@@ -2827,7 +2814,7 @@ export const Calendar = React.memo(
                         options,
                         element: null,
                         props,
-                        multiplePickerYear,
+                        switchToYearView,
                         currentView,
                         displayYear: metaYear
                     };
@@ -3076,8 +3063,7 @@ export const Calendar = React.memo(
                 currentView
             };
 
-            const header = props.headerTemplate && index === 0 ? props.headerTemplate(headerTemplateProps) : null;
-            const headerRight = props.headerRightTemplate && index === (props.numberOfMonths || 1) - 1 ? props.headerRightTemplate(headerTemplateProps) : null;
+            const header = props.headerTemplate ? props.headerTemplate(headerTemplateProps) : null;
             const monthKey = monthMetaData.month + '-' + monthMetaData.year;
             const groupProps = mergeProps(
                 {
@@ -3101,7 +3087,6 @@ export const Calendar = React.memo(
                         {backwardNavigator}
                         {title}
                         {forwardNavigator}
-                        {headerRight}
                     </div>
                     {dateViewGrid}
                 </div>

--- a/components/lib/calendar/CalendarBase.js
+++ b/components/lib/calendar/CalendarBase.js
@@ -246,6 +246,7 @@ export const CalendarBase = ComponentBase.extend({
         footerTemplate: null,
         formatDateTime: null,
         headerTemplate: null,
+        headerRightTemplate: null,
         hideOnDateTimeSelect: false,
         hourFormat: '24',
         icon: null,

--- a/components/lib/calendar/CalendarBase.js
+++ b/components/lib/calendar/CalendarBase.js
@@ -246,7 +246,6 @@ export const CalendarBase = ComponentBase.extend({
         footerTemplate: null,
         formatDateTime: null,
         headerTemplate: null,
-        headerRightTemplate: null,
         hideOnDateTimeSelect: false,
         hourFormat: '24',
         icon: null,

--- a/components/lib/calendar/calendar.d.ts
+++ b/components/lib/calendar/calendar.d.ts
@@ -286,6 +286,10 @@ export interface CalendarState {
      * Current viewDate state.
      */
     viewDate: Nullable<Date>;
+    /**
+     * 多面板是否打开了年/月选择框
+     */
+    multiplePickerShow: boolean;
 }
 
 /**
@@ -440,6 +444,22 @@ interface CalendarDateTemplateEvent {
     selectable: boolean;
 }
 
+interface CalendarHeaderTemplateEvent {
+    /**
+     * 前一年
+     */
+    navBackwardYear: () => void;
+    /**
+     * 后一年
+     * @returns
+     */
+    navForwardYear: () => void;
+    /**
+     * 当前面板
+     */
+    currentView: undefined | 'date' | 'month' | 'year';
+}
+
 /**
  * Custom visible change event
  * @see {@link CalendarProps.onVisibleChange}
@@ -503,7 +523,21 @@ interface CalendarNavigatorTemplateEvent {
  * @extends {CalendarNavigatorTemplateEvent}
  * @event
  */
-interface CalendarMonthNavigatorTemplateEvent extends CalendarNavigatorTemplateEvent {}
+interface CalendarMonthNavigatorTemplateEvent extends CalendarNavigatorTemplateEvent {
+    /**
+     * 打开月选择器
+     * @returns
+     */
+    multiplePickerMonth: () => void;
+    /**
+     * 当前面板
+     */
+    currentView: undefined | 'date' | 'month' | 'year';
+    /**
+     * 当前月份
+     */
+    displayMonth: string;
+}
 
 /**
  * Custom year navigator template event
@@ -511,7 +545,21 @@ interface CalendarMonthNavigatorTemplateEvent extends CalendarNavigatorTemplateE
  * @extends {CalendarNavigatorTemplateEvent}
  * @event
  */
-interface CalendarYearNavigatorTemplateEvent extends CalendarNavigatorTemplateEvent {}
+interface CalendarYearNavigatorTemplateEvent extends CalendarNavigatorTemplateEvent {
+    /**
+     * 打开年选择器
+     * @returns
+     */
+    multiplePickerYear: () => void;
+    /**
+     * 当前面板
+     */
+    currentView: undefined | 'date' | 'month' | 'year';
+    /**
+     * 当前年份
+     */
+    displayYear: string;
+}
 
 /**
  * Defines valid base properties in Calendar component.
@@ -867,7 +915,12 @@ interface CalendarBaseProps {
      * Custom header template of overlay.
      * @return {React.ReactNode}
      */
-    headerTemplate?(): React.ReactNode;
+    headerTemplate?(event: CalendarHeaderTemplateEvent): React.ReactNode;
+    /**
+     * Custom header template of overlay.
+     * @return {React.ReactNode}
+     */
+    headerRightTemplate?(event: CalendarHeaderTemplateEvent): React.ReactNode;
     /**
      * Function that gets a navigator information and returns the navigator element in header.
      * @param {CalendarMonthNavigatorTemplateEvent} event - Custom month navigator template event.

--- a/components/lib/calendar/calendar.d.ts
+++ b/components/lib/calendar/calendar.d.ts
@@ -30,6 +30,8 @@ export interface CalendarPassThroughMethodOptions {
     context: CalendarContext;
 }
 
+export type TCurrentView = undefined | 'date' | 'month' | 'year';
+
 /**
  * Custom passthrough(pt) options.
  * @see {@link CalendarProps.pt}
@@ -287,9 +289,9 @@ export interface CalendarState {
      */
     viewDate: Nullable<Date>;
     /**
-     * 多面板是否打开了年/月选择框
+     * 当前面板
      */
-    multiplePickerShow: boolean;
+    currentView: TCurrentView;
 }
 
 /**
@@ -457,7 +459,7 @@ interface CalendarHeaderTemplateEvent {
     /**
      * 当前面板
      */
-    currentView: undefined | 'date' | 'month' | 'year';
+    currentView: TCurrentView;
 }
 
 /**
@@ -528,11 +530,11 @@ interface CalendarMonthNavigatorTemplateEvent extends CalendarNavigatorTemplateE
      * 打开月选择器
      * @returns
      */
-    multiplePickerMonth: () => void;
+    switchToMonthView: () => void;
     /**
      * 当前面板
      */
-    currentView: undefined | 'date' | 'month' | 'year';
+    currentView: TCurrentView;
     /**
      * 当前月份
      */
@@ -550,11 +552,11 @@ interface CalendarYearNavigatorTemplateEvent extends CalendarNavigatorTemplateEv
      * 打开年选择器
      * @returns
      */
-    multiplePickerYear: () => void;
+    switchToYearView: () => void;
     /**
      * 当前面板
      */
-    currentView: undefined | 'date' | 'month' | 'year';
+    currentView: TCurrentView;
     /**
      * 当前年份
      */
@@ -916,11 +918,6 @@ interface CalendarBaseProps {
      * @return {React.ReactNode}
      */
     headerTemplate?(event: CalendarHeaderTemplateEvent): React.ReactNode;
-    /**
-     * Custom header template of overlay.
-     * @return {React.ReactNode}
-     */
-    headerRightTemplate?(event: CalendarHeaderTemplateEvent): React.ReactNode;
     /**
      * Function that gets a navigator information and returns the navigator element in header.
      * @param {CalendarMonthNavigatorTemplateEvent} event - Custom month navigator template event.

--- a/components/lib/hooks/useStyle.js
+++ b/components/lib/hooks/useStyle.js
@@ -17,7 +17,7 @@ export const useStyle = (css, options = {}) => {
     };
 
     const load = () => {
-        if (!document) return;
+        if (!document || isLoaded) return;
 
         styleRef.current = document.querySelector(`style[data-primereact-style-id="${name}"]`) || document.getElementById(id) || document.createElement('style');
 
@@ -30,8 +30,6 @@ export const useStyle = (css, options = {}) => {
             document.head.appendChild(styleRef.current);
             name && styleRef.current.setAttribute('data-primereact-style-id', name);
         }
-
-        if (isLoaded) return;
 
         styleRef.current.textContent = css;
 
@@ -50,7 +48,7 @@ export const useStyle = (css, options = {}) => {
 
         // return () => {if (!manual) unload()}; /* @todo */
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [manual]);
 
     return {
         id,

--- a/components/lib/ripple/Ripple.js
+++ b/components/lib/ripple/Ripple.js
@@ -10,16 +10,15 @@ export const Ripple = React.memo(
         const targetRef = React.useRef(null);
         const context = React.useContext(PrimeReactContext);
         const props = RippleBase.getProps(inProps, context);
-
+        const isRippleActive = (context && context.ripple) || PrimeReact.ripple;
         const metaData = {
             props
         };
-
-        useStyle(RippleBase.css.styles, { name: 'ripple' });
-
         const { ptm, cx } = RippleBase.setMetaData({
             ...metaData
         });
+
+        useStyle(RippleBase.css.styles, { name: 'ripple', manual: !isRippleActive });
 
         const getTarget = () => {
             return inkRef.current && inkRef.current.parentElement;
@@ -101,6 +100,8 @@ export const Ripple = React.memo(
             }
         });
 
+        if (!isRippleActive) return null;
+
         const rootProps = mergeProps(
             {
                 'aria-hidden': true,
@@ -110,7 +111,7 @@ export const Ripple = React.memo(
             ptm('root')
         );
 
-        return (context && context.ripple) || PrimeReact.ripple ? <span role="presentation" ref={inkRef} {...rootProps} onAnimationEnd={onAnimationEnd}></span> : null;
+        return <span role="presentation" ref={inkRef} {...rootProps} onAnimationEnd={onAnimationEnd}></span>;
     })
 );
 


### PR DESCRIPTION
1. 在`CalendarState`中挂载了属性`currentView` 
2. 在`monthNavigatorTemplate`方法的第一个参数进行了如下修改
	1. 移除了默认的`monthsNavigator`下拉选取行为
	2. 挂载了`switchToMonthView`方法
	3. 新增了`displayMonth`属性，标识当前面板对应的月份 
3. 在`yearNavigatorTemplate`方法的第一个参数进行了如下修改
	1. 移除了默认的`yearNavigator`下拉选取行为
	2. 挂载了`switchToYearView`方法
	3. 新增了`displayYear`属性，标识当前面板对应的年份
4. 新增了方法`navBackwardYear`和方法`navForwardYear`，用于向前或向后切换一年
5. 给`headerTemplate`方法新增了一个参数，包含的内容如下：
	1. `navBackwardYear`方法
	2. `navForwardYear`方法
	3. `currentView`属性   
6. 调整了年份切换器单页可见的年份数量，从10个调整为12