### PR TITLE
日期选择器修改

### DIFF
--- a/components/lib/calendar/Calendar.js
+++ b/components/lib/calendar/Calendar.js
@@ -1537,12 +1537,8 @@ export const Calendar = React.memo(
 
         const onOverlayEntered = () => {
             if (!props.touchUI && overlayRef && overlayRef.current && inputRef && inputRef.current && !appendDisabled()) {
-                if (props.view === 'date') {
-                    overlayRef.current.style.width = DomHandler.getOuterWidth(overlayRef.current) + 'px';
-                    overlayRef.current.style.minWidth = DomHandler.getOuterWidth(inputRef.current) + 'px';
-                } else {
-                    overlayRef.current.style.width = DomHandler.getOuterWidth(inputRef.current) + 'px';
-                }
+                overlayRef.current.style.width = DomHandler.getOuterWidth(overlayRef.current) + 'px';
+                overlayRef.current.style.minWidth = DomHandler.getOuterWidth(inputRef.current) + 'px';
             }
 
             bindOverlayListener();


### PR DESCRIPTION
 fix: 月、年选择器的面板宽度始终与输入框大小相同